### PR TITLE
Replace ask command with chat command in CLI.

### DIFF
--- a/mindflow/cli/new_click_cli/cli_main.py
+++ b/mindflow/cli/new_click_cli/cli_main.py
@@ -1,6 +1,6 @@
 import click
 
-from mindflow.cli.new_click_cli.commands.ask import ask
+from mindflow.cli.new_click_cli.commands.chat import chat
 from mindflow.cli.new_click_cli.commands.commit import commit
 from mindflow.cli.new_click_cli.commands.delete import delete
 from mindflow.cli.new_click_cli.commands.diff import diff
@@ -26,7 +26,7 @@ def version():
     click.echo(__version__)
 
 
-mindflow_cli.add_command(ask)
+mindflow_cli.add_command(chat)
 mindflow_cli.add_command(commit)
 mindflow_cli.add_command(delete)
 mindflow_cli.add_command(diff)

--- a/mindflow/cli/new_click_cli/commands/chat.py
+++ b/mindflow/cli/new_click_cli/commands/chat.py
@@ -3,13 +3,13 @@
 """
 import click
 
-from mindflow.core.ask import run_ask
+from mindflow.core.chat import run_chat
 
 
 @click.command(help="")
 @click.argument("prompt", type=str)
-def ask(prompt: str):
+def chat(prompt: str):
     """
     This function is used to generate a prompt and then use it as a prompt for GPT bot.
     """
-    print(run_ask(prompt))
+    print(run_chat(prompt))

--- a/mindflow/cli/new_click_cli/commands/config.py
+++ b/mindflow/cli/new_click_cli/commands/config.py
@@ -3,7 +3,7 @@
 """
 import click
 
-from mindflow.cli.config.main import set_configuration
+from mindflow.cli.config import set_configuration
 
 
 @click.command(help="Advanced setup custom mindflow configurations.")

--- a/mindflow/core/chat.py
+++ b/mindflow/core/chat.py
@@ -1,8 +1,6 @@
 from mindflow.settings import Settings
-from mindflow.utils.response import handle_response_text
 
-
-def run_ask(prompt: str) -> str:
+def run_chat(prompt: str) -> str:
     """
     This function is used to generate a prompt and then use it as a prompt for GPT bot.
     """

--- a/mindflow/unit_tests/test_cli.py
+++ b/mindflow/unit_tests/test_cli.py
@@ -9,3 +9,11 @@ def test_version():
     result = runner.invoke(mindflow_cli, ["version"])
     assert result.exit_code == 0
     assert result.output == f"{mindflow.__version__}\n"
+
+
+def test_chat():
+    runner = CliRunner()
+    result = runner.invoke(mindflow_cli, ["chat", "Whats up Mindflow?"])
+
+    assert result.exit_code == 0
+    assert result.output == "Chat with Mindflow!\n"

--- a/mindflow/utils/prompts.py
+++ b/mindflow/utils/prompts.py
@@ -18,6 +18,6 @@ INDEX_PROMPT_PREFIX = "Pretend you are a search engine trying to provide an info
          the full content and purpose of this file."
 COMMIT_PROMPT_PREFIX = "Please provide a commit message for the following changes. Only respond with the commit message and nothing else."
 PR_TITLE_PREFIX = "Please provide a title for the following pull request using this git diff summary. Only respond with the title and nothing else."
-PR_BODY_PREFIX = "Please provide a body for the following pull request using this git diff summary. I'd like it to include, bulleted summaries of \
-    changes and titles to give a coherent picture of what has changed. Only respond with the body and nothing else."
+PR_BODY_PREFIX = "Please provide a body for the following pull request using this git diff summary. I want you to keep it high level, and give core \
+      themes and reasons for changes Only respond with the body and nothing else."
 QUERY = "Please answer the following query like a helpful virtual assistant using the context provided below: "


### PR DESCRIPTION
This pull request includes changes to several files in the codebase. The main changes include renaming the `ask` module to `chat` and replacing the `ask` command with the `chat` command. The `chat` command has been imported from the `commands.chat` module and added to the `mindflow_cli.add_command()` function call. The `run_ask` function call has been replaced with `run_chat` function call. Additionally, a new test function `test_chat()` has been added to test the `chat` command. Finally, the prompt message for `PR_BODY_PREFIX` has been updated.