### PR TITLE
Add passthrough_command decorator and message_overwrite argument to commit and diff functions

### DIFF
--- a/mindflow/cli/new_click_cli/commands/commit.py
+++ b/mindflow/cli/new_click_cli/commands/commit.py
@@ -6,8 +6,14 @@ from mindflow.cli.new_click_cli.util import passthrough_command
 
 
 @passthrough_command(help="Generate a git commit response by feeding git diff to gpt")
-def commit(args: Tuple[str]):
+@click.option("-m", "--message", help="Don't use mindflow to generate a commit message, use this one instead.", default=None)
+def commit(args: Tuple[str], message: str = None):
     """
     Commit command.
     """
-    print(run_commit(args))
+
+    if message is not None:
+        click.echo(f"Warning: Using message '{message}' instead of mindflow generated message.")
+        click.echo("It's recommended that you don't use the -m/--message flag.")
+
+    print(run_commit(args, message_overwrite=message))

--- a/mindflow/cli/new_click_cli/commands/commit.py
+++ b/mindflow/cli/new_click_cli/commands/commit.py
@@ -1,8 +1,9 @@
+from typing import Tuple, Optional
+
 import click
 
-from typing import Tuple
-from mindflow.core.commit import run_commit
 from mindflow.cli.new_click_cli.util import passthrough_command
+from mindflow.core.commit import run_commit
 
 
 @passthrough_command(help="Generate a git commit response by feeding git diff to gpt")
@@ -12,7 +13,7 @@ from mindflow.cli.new_click_cli.util import passthrough_command
     help="Don't use mindflow to generate a commit message, use this one instead.",
     default=None,
 )
-def commit(args: Tuple[str], message: str = None):
+def commit(args: Tuple[str], message: Optional[str] = None):
     """
     Commit command.
     """

--- a/mindflow/cli/new_click_cli/commands/commit.py
+++ b/mindflow/cli/new_click_cli/commands/commit.py
@@ -1,11 +1,13 @@
 import click
 
+from typing import Tuple
 from mindflow.core.commit import run_commit
+from mindflow.cli.new_click_cli.util import passthrough_command
 
 
-@click.command(help="Generate a git commit response by feeding git diff to gpt")
-def commit():
+@passthrough_command(help="Generate a git commit response by feeding git diff to gpt")
+def commit(args: Tuple[str]):
     """
     Commit command.
     """
-    print(run_commit(user_confirm=True))
+    print(run_commit(args))

--- a/mindflow/cli/new_click_cli/commands/commit.py
+++ b/mindflow/cli/new_click_cli/commands/commit.py
@@ -8,4 +8,4 @@ def commit():
     """
     Commit command.
     """
-    print(run_commit())
+    print(run_commit(user_confirm=True))

--- a/mindflow/cli/new_click_cli/commands/commit.py
+++ b/mindflow/cli/new_click_cli/commands/commit.py
@@ -6,14 +6,21 @@ from mindflow.cli.new_click_cli.util import passthrough_command
 
 
 @passthrough_command(help="Generate a git commit response by feeding git diff to gpt")
-@click.option("-m", "--message", help="Don't use mindflow to generate a commit message, use this one instead.", default=None)
+@click.option(
+    "-m",
+    "--message",
+    help="Don't use mindflow to generate a commit message, use this one instead.",
+    default=None,
+)
 def commit(args: Tuple[str], message: str = None):
     """
     Commit command.
     """
 
     if message is not None:
-        click.echo(f"Warning: Using message '{message}' instead of mindflow generated message.")
+        click.echo(
+            f"Warning: Using message '{message}' instead of mindflow generated message."
+        )
         click.echo("It's recommended that you don't use the -m/--message flag.")
 
     print(run_commit(args, message_overwrite=message))

--- a/mindflow/cli/new_click_cli/commands/diff.py
+++ b/mindflow/cli/new_click_cli/commands/diff.py
@@ -3,17 +3,9 @@
 """
 from typing import Tuple
 
-import click
-
 from mindflow.core.diff import run_diff
+from mindflow.cli.new_click_cli.util import passthrough_command
 
-
-@click.command(
-    context_settings=dict(
-        ignore_unknown_options=True,
-    ),
-    help="Wrapper around git diff that summarizes the output. Treat this command exactly like git diff, it supports all arguments that git diff provides.",
-)
-@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+@passthrough_command(help="Wrapper around git diff that summarizes the output. Treat this command exactly like git diff, it supports all arguments that git diff provides.")
 def diff(args: Tuple[str]):
     print(run_diff(args))

--- a/mindflow/cli/new_click_cli/commands/diff.py
+++ b/mindflow/cli/new_click_cli/commands/diff.py
@@ -6,6 +6,9 @@ from typing import Tuple
 from mindflow.core.diff import run_diff
 from mindflow.cli.new_click_cli.util import passthrough_command
 
-@passthrough_command(help="Wrapper around git diff that summarizes the output. Treat this command exactly like git diff, it supports all arguments that git diff provides.")
+
+@passthrough_command(
+    help="Wrapper around git diff that summarizes the output. Treat this command exactly like git diff, it supports all arguments that git diff provides."
+)
 def diff(args: Tuple[str]):
     print(run_diff(args))

--- a/mindflow/cli/new_click_cli/commands/diff.py
+++ b/mindflow/cli/new_click_cli/commands/diff.py
@@ -3,8 +3,8 @@
 """
 from typing import Tuple
 
-from mindflow.core.diff import run_diff
 from mindflow.cli.new_click_cli.util import passthrough_command
+from mindflow.core.diff import run_diff
 
 
 @passthrough_command(

--- a/mindflow/cli/new_click_cli/util.py
+++ b/mindflow/cli/new_click_cli/util.py
@@ -1,0 +1,21 @@
+import click
+
+
+def passthrough_command(*command_args, **command_kwargs):
+    # this function is a decorator that takes the input function and wraps it
+    def _decorator(func):
+        
+        context_settings = command_kwargs.get("context_settings", {})
+
+        if "ignore_unknown_options" in context_settings:
+            raise ValueError("The context_settings argument already has an entry for 'ignore_unknown_options'")
+
+        dec1 = click.command(*command_args, context_settings=dict(context_settings, ignore_unknown_options=True), **command_kwargs)
+
+        dec2 = click.argument("args", nargs=-1, type=click.UNPROCESSED)
+
+        func = dec1(func)
+        func = dec2(func)
+        return func
+    
+    return _decorator

--- a/mindflow/cli/new_click_cli/util.py
+++ b/mindflow/cli/new_click_cli/util.py
@@ -4,18 +4,23 @@ import click
 def passthrough_command(*command_args, **command_kwargs):
     # this function is a decorator that takes the input function and wraps it
     def _decorator(func):
-        
         context_settings = command_kwargs.get("context_settings", {})
 
         if "ignore_unknown_options" in context_settings:
-            raise ValueError("The context_settings argument already has an entry for 'ignore_unknown_options'")
+            raise ValueError(
+                "The context_settings argument already has an entry for 'ignore_unknown_options'"
+            )
 
-        dec1 = click.command(*command_args, context_settings=dict(context_settings, ignore_unknown_options=True), **command_kwargs)
+        dec1 = click.command(
+            *command_args,
+            context_settings=dict(context_settings, ignore_unknown_options=True),
+            **command_kwargs
+        )
 
         dec2 = click.argument("args", nargs=-1, type=click.UNPROCESSED)
 
         func = dec1(func)
         func = dec2(func)
         return func
-    
+
     return _decorator

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -23,6 +23,9 @@ def run_commit(args: Tuple[str]) -> str:
         build_context_prompt(COMMIT_PROMPT_PREFIX, diff_output)
     )
 
+    # add co-authorship to commit message
+    response += "\n\nCo-authored-by: MindFlow <mf@mindflo.ai>"
+
     command = ["git", "commit", "-m"] + [response] + list(args)
 
     # Execute the git diff command and retrieve the output as a string

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -1,14 +1,13 @@
 import subprocess
+from typing import Tuple, Optional
 
 from mindflow.core.diff import run_diff
 from mindflow.settings import Settings
 from mindflow.utils.prompt_builders import build_context_prompt
 from mindflow.utils.prompts import COMMIT_PROMPT_PREFIX
 
-from typing import Tuple
 
-
-def run_commit(args: Tuple[str], message_overwrite: str = None) -> str:
+def run_commit(args: Tuple[str], message_overwrite: Optional[str] = None) -> str:
     """
     Commit command.
     """

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -8,7 +8,7 @@ from mindflow.utils.prompts import COMMIT_PROMPT_PREFIX
 from typing import Tuple
 
 
-def run_commit(args: Tuple[str], message_overwrite: str=None) -> str:
+def run_commit(args: Tuple[str], message_overwrite: str = None) -> str:
     """
     Commit command.
     """

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -8,7 +8,7 @@ from mindflow.utils.prompts import COMMIT_PROMPT_PREFIX
 from typing import Tuple
 
 
-def run_commit(args: Tuple[str]) -> str:
+def run_commit(args: Tuple[str], message_overwrite: str=None) -> str:
     """
     Commit command.
     """
@@ -17,14 +17,17 @@ def run_commit(args: Tuple[str]) -> str:
     if not has_staged_files():
         return "No staged files"
 
-    # Execute the git diff command and retrieve the output as a string
-    diff_output = run_diff(("--cached",))
-    response: str = settings.mindflow_models.query.model(
-        build_context_prompt(COMMIT_PROMPT_PREFIX, diff_output)
-    )
+    if message_overwrite is None:
+        # Execute the git diff command and retrieve the output as a string
+        diff_output = run_diff(("--cached",))
+        response: str = settings.mindflow_models.query.model(
+            build_context_prompt(COMMIT_PROMPT_PREFIX, diff_output)
+        )
 
-    # add co-authorship to commit message
-    response += "\n\nCo-authored-by: MindFlow <mf@mindflo.ai>"
+        # add co-authorship to commit message
+        response += "\n\nCo-authored-by: MindFlow <mf@mindflo.ai>"
+    else:
+        response = message_overwrite
 
     command = ["git", "commit", "-m"] + [response] + list(args)
 

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -6,7 +6,7 @@ from mindflow.utils.prompt_builders import build_context_prompt
 from mindflow.utils.prompts import COMMIT_PROMPT_PREFIX
 
 
-def run_commit() -> str:
+def run_commit(user_confirm: bool = False) -> str:
     """
     Commit command.
     """
@@ -20,6 +20,11 @@ def run_commit() -> str:
     response: str = settings.mindflow_models.query.model(
         build_context_prompt(COMMIT_PROMPT_PREFIX, diff_output)
     )
+
+    if user_confirm:
+        import click
+        click.echo(f"\n-----------------\n{response}\n-----------------\n")
+        click.confirm(f"Commit with the above message?", abort=True)
 
     command = ["git", "commit", "-m"] + [response]
 

--- a/mindflow/core/commit.py
+++ b/mindflow/core/commit.py
@@ -5,8 +5,10 @@ from mindflow.settings import Settings
 from mindflow.utils.prompt_builders import build_context_prompt
 from mindflow.utils.prompts import COMMIT_PROMPT_PREFIX
 
+from typing import Tuple
 
-def run_commit(user_confirm: bool = False) -> str:
+
+def run_commit(args: Tuple[str]) -> str:
     """
     Commit command.
     """
@@ -21,12 +23,7 @@ def run_commit(user_confirm: bool = False) -> str:
         build_context_prompt(COMMIT_PROMPT_PREFIX, diff_output)
     )
 
-    if user_confirm:
-        import click
-        click.echo(f"\n-----------------\n{response}\n-----------------\n")
-        click.confirm(f"Commit with the above message?", abort=True)
-
-    command = ["git", "commit", "-m"] + [response]
+    command = ["git", "commit", "-m"] + [response] + list(args)
 
     # Execute the git diff command and retrieve the output as a string
     output = subprocess.check_output(command).decode("utf-8")

--- a/mindflow/core/pr.py
+++ b/mindflow/core/pr.py
@@ -1,7 +1,6 @@
+import concurrent.futures
 import subprocess
 from typing import List
-
-import concurrent.futures
 
 from mindflow.core.diff import run_diff
 from mindflow.settings import Settings


### PR DESCRIPTION
This pull request includes several changes across multiple files. Here is a summary of the changes:

- `commit.py`
    - Added an import statement for Tuple
    - Added a `passthrough_command` decorator to the `commit` function
    - Added a `click.option` decorator for the `message` argument
    - Added logic to handle the `message_overwrite` argument

- `diff.py`
    - Added a `passthrough_command` decorator to the `diff` function
    - Removed the `click.argument` decorator and added it to the decorator function

- `util.py`
    - Added a new file with a decorator function called `passthrough_command`

- `core/commit.py`
    - Added an import statement for Tuple
    - Added a `message_overwrite` argument to the `run_commit` function
    - Added logic to handle the `message_overwrite` argument and add co-authorship to the commit message

These changes add functionality to the `commit` and `diff` functions, as well as introduce a new decorator function that can be used to pass arguments through to other functions. Additionally, the changes to `core/commit.py` allow for co-authorship to be added to commit messages.