### PR TITLE
Added git pull request options and utility functions for flag parsing and git diff parsing

### DIFF
--- a/mindflow/cli/new_click_cli/commands/git/commit.py
+++ b/mindflow/cli/new_click_cli/commands/git/commit.py
@@ -7,6 +7,12 @@ from mindflow.core.git.commit import run_commit
 
 
 @passthrough_command(help="Generate a git commit response by feeding git diff to gpt")
+# @overloaded_option(
+#     "-m",
+#     "--message",
+#     help="Don't use mindflow to generate a commit message, use this one instead.",
+#     default=None,
+# )
 @click.option(
     "-m",
     "--message",
@@ -17,7 +23,6 @@ def commit(args: Tuple[str], message: Optional[str] = None):
     """
     Commit command.
     """
-
     if message is not None:
         click.echo(
             f"Warning: Using message '{message}' instead of mindflow generated message."

--- a/mindflow/cli/new_click_cli/commands/git/mr.py
+++ b/mindflow/cli/new_click_cli/commands/git/mr.py
@@ -28,7 +28,7 @@ def mr():
     help="Don't use mindflow to generate a pr body, use this one instead.",
     default=None,
 )
-def create(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = None):
+def create(args: Tuple[str], title: Optional[str] = None, description: Optional[str] = None):
     """
     PR command.
     """
@@ -36,15 +36,15 @@ def create(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = 
         click.echo(
             f"Warning: Using message '{title}' instead of mindflow generated message."
         )
-        click.echo("It's recommended that you don't use the -m/--message flag.")
+        click.echo("It's recommended that you don't use the -t/--title flag.")
     
-    if body is not None:
+    if description is not None:
         click.echo(
-            f"Warning: Using message '{body}' instead of mindflow generated message."
+            f"Warning: Using message '{description}' instead of mindflow generated message."
         )
-        click.echo("It's recommended that you don't use the -m/--message flag.")
+        click.echo("It's recommended that you don't use the -d/--description flag.")
 
-    run_mr(args, title_overwrite=title, body_overwrite=body)
+    run_mr(args, title=title, description=description)
 
 
 mr.add_command(create)

--- a/mindflow/cli/new_click_cli/commands/git/mr.py
+++ b/mindflow/cli/new_click_cli/commands/git/mr.py
@@ -2,13 +2,13 @@ from typing import Optional, Tuple
 
 import click
 from mindflow.cli.new_click_cli.util import passthrough_command
-from mindflow.core.git.pr import run_pr
+from mindflow.core.git.mr import run_mr
 
 
 @click.group()
-def pr():
+def mr():
     """
-    PR command.
+    MR command.
     """
     pass
 
@@ -23,8 +23,8 @@ def pr():
     default=None,
 )
 @click.option(
-    "-b",
-    "--body",
+    "-d",
+    "--description",
     help="Don't use mindflow to generate a pr body, use this one instead.",
     default=None,
 )
@@ -44,7 +44,7 @@ def create(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = 
         )
         click.echo("It's recommended that you don't use the -m/--message flag.")
 
-    run_pr(args, title=title, body=body)
+    run_mr(args, title_overwrite=title, body_overwrite=body)
 
 
-pr.add_command(create)
+mr.add_command(create)

--- a/mindflow/cli/new_click_cli/commands/git/pr.py
+++ b/mindflow/cli/new_click_cli/commands/git/pr.py
@@ -36,13 +36,13 @@ def create(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = 
         click.echo(
             f"Warning: Using message '{title}' instead of mindflow generated message."
         )
-        click.echo("It's recommended that you don't use the -m/--message flag.")
+        click.echo("It's recommended that you don't use the -t/--title flag.")
     
     if body is not None:
         click.echo(
             f"Warning: Using message '{body}' instead of mindflow generated message."
         )
-        click.echo("It's recommended that you don't use the -m/--message flag.")
+        click.echo("It's recommended that you don't use the -d/--description flag.")
 
     run_pr(args, title=title, body=body)
 

--- a/mindflow/cli/new_click_cli/util.py
+++ b/mindflow/cli/new_click_cli/util.py
@@ -2,7 +2,8 @@ import click
 
 
 def passthrough_command(*command_args, **command_kwargs):
-    # this function is a decorator that takes the input function and wraps it
+    """Just like the @click.command decorator, but allows all args to pass through (for wrapper cli commands)."""
+
     def _decorator(func):
         context_settings = command_kwargs.get("context_settings", {})
 
@@ -24,3 +25,40 @@ def passthrough_command(*command_args, **command_kwargs):
         return func
 
     return _decorator
+
+# def overloaded_option(*option_args, **option_kwargs):
+    # if message is not None:
+    #     click.echo(
+    #         f"Warning: Using message '{message}' instead of mindflow generated message."
+    #     )
+    #     click.echo("It's recommended that you don't use the -m/--message flag.")
+
+
+    # @click.option(
+    #     "-m",
+    #     "--message",
+    #     help="Don't use mindflow to generate a commit message, use this one instead.",
+    #     default=None,
+    # )
+
+    # def _decorator(func):
+    #     dec1 = click.option(*option_args, **option_kwargs)
+
+    #     func = dec1(func)
+    #     print(func)
+    #     # option_name = func.params[-1].name
+    #     option_name = func.__click_params__[-1].name
+
+    #     def wrapped_func(**kwargs):
+    #         if option_name in kwargs:
+    #             v = kwargs[option_name]
+    #             click.echo(
+    #                 f"Warning: MindFlow overrides {option_name}, but since you passed in it's value as '{v}', that will be used instead."
+    #             )
+    #             click.echo("We recommend not overriding options, but we understand sometimes it's necessary.")
+            
+    #         return func(**kwargs)
+
+    #     return wrapped_func
+    
+    # return _decorator

--- a/mindflow/core/git/mr.py
+++ b/mindflow/core/git/mr.py
@@ -1,0 +1,29 @@
+import subprocess
+from typing import Optional, Tuple, List
+
+from mindflow.core.git.pr import create_title_and_body, is_valid_pr
+from mindflow.utils.command_parse import get_flag_value
+
+def run_mr(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = None) -> str:
+    base_branch = get_flag_value(args, ['--target-branch', '-b'])
+    head_branch = get_flag_value(args, ['--source-branch', '-s'])
+
+    if not is_valid_pr(get_flag_value(args, base_branch, head_branch)):
+        return
+
+    if not title or not body:
+        title, body = create_title_and_body(base_branch, title, body)
+
+    create_merge_request(args, title, body)
+
+def create_merge_request(args: Tuple[str], title: str, body: str):
+    command: List[str] = ["glab", "pr", "create"] + + list(args) + ["--title", title, "--description", body] # type: ignore
+    pr_result = subprocess.check_output(command).decode("utf-8")
+    if "https://" in pr_result:
+        print("Merge request created successfully")
+        print(pr_result)
+    else:
+        print(
+            "Failed to create pull request. Please raise an issue at: https://github.com/nollied/mindflow-cli/issues"
+        )
+        exit()

--- a/mindflow/core/git/pr.py
+++ b/mindflow/core/git/pr.py
@@ -13,6 +13,23 @@ def run_pr(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = 
     base_branch = get_flag_value(args, ['--base', '-B'])
     head_branch = get_flag_value(args, ['--head', '-H'])
 
+    if base_branch is None:
+        # Determine the name of the default branch
+        base_branch = (
+            subprocess.check_output(["git", "symbolic-ref", "refs/remotes/origin/HEAD"])
+            .decode()
+            .strip()
+            .split("/")[-1]
+        )
+    
+    if head_branch is None:
+        # Get the name of the current branch
+        head_branch = (
+            subprocess.check_output(["git", "symbolic-ref", "--short", "HEAD"])
+            .decode("utf-8")
+            .strip()
+        )
+
     if not is_valid_pr(base_branch, head_branch):
         return
 
@@ -22,23 +39,6 @@ def run_pr(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = 
     create_pull_request(args, title, body)
 
 def is_valid_pr(head_branch: Optional[str], base_branch: Optional[str]) -> bool:
-    if head_branch is None:
-        # Get the name of the current branch
-        head_branch = (
-            subprocess.check_output(["git", "symbolic-ref", "--short", "HEAD"])
-            .decode("utf-8")
-            .strip()
-        )
-    
-    if base_branch is None:
-        # Determine the name of the default branch
-        base_branch = (
-            subprocess.check_output(["git", "symbolic-ref", "refs/remotes/origin/HEAD"])
-            .decode()
-            .strip()
-            .split("/")[-1]
-        )
-
     if head_branch == base_branch:
         print("Cannot create pull request from default branch")
         return False

--- a/mindflow/core/git/pr.py
+++ b/mindflow/core/git/pr.py
@@ -1,35 +1,49 @@
 import concurrent.futures
 import subprocess
-from typing import List
+from typing import List, Optional, Tuple
 
 from mindflow.core.git.diff import run_diff
 from mindflow.settings import Settings
+from mindflow.utils.command_parse import get_flag_value
 from mindflow.utils.prompt_builders import build_context_prompt
 from mindflow.utils.prompts import PR_BODY_PREFIX
 from mindflow.utils.prompts import PR_TITLE_PREFIX
 
+def run_pr(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = None) -> str:
+    base_branch = get_flag_value(args, ['--base', '-B'])
+    head_branch = get_flag_value(args, ['--head', '-H'])
 
-def run_pr():
-    # Get the name of the current branch
-    current_branch = (
-        subprocess.check_output(["git", "symbolic-ref", "--short", "HEAD"])
-        .decode("utf-8")
-        .strip()
-    )
+    if not is_valid_pr(base_branch, head_branch):
+        return
 
-    # Determine the name of the default branch
-    default_branch = (
-        subprocess.check_output(["git", "symbolic-ref", "refs/remotes/origin/HEAD"])
-        .decode()
-        .strip()
-        .split("/")[-1]
-    )
+    if not title or not body:
+        title, body = create_title_and_body(base_branch, title, body)
 
-    if current_branch == default_branch:
+    create_pull_request(args, title, body)
+
+def is_valid_pr(head_branch: Optional[str], base_branch: Optional[str]):
+    if head_branch is None:
+        # Get the name of the current branch
+        head_branch = (
+            subprocess.check_output(["git", "symbolic-ref", "--short", "HEAD"])
+            .decode("utf-8")
+            .strip()
+        )
+    
+    if base_branch is None:
+        # Determine the name of the default branch
+        base_branch = (
+            subprocess.check_output(["git", "symbolic-ref", "refs/remotes/origin/HEAD"])
+            .decode()
+            .strip()
+            .split("/")[-1]
+        )
+
+    if head_branch == base_branch:
         print("Cannot create pull request from default branch")
         return
 
-    if not has_remote_branch(current_branch):
+    if not has_remote_branch(head_branch):
         print("No remote branch for current branch")
         return
 
@@ -37,25 +51,34 @@ def run_pr():
         print("Current branch needs to be pushed to remote repository")
         return
 
+def create_title_and_body(base_branch, title: Optional[str], body: Optional[str]) -> Tuple[str, str]:
     settings = Settings()
 
-    diff_output = run_diff((default_branch,))
+    diff_output = run_diff((base_branch,))
 
-    pr_title_prompt = build_context_prompt(PR_TITLE_PREFIX, diff_output)
-    pr_body_prompt = build_context_prompt(PR_BODY_PREFIX, diff_output)
+    if title is None and body is None:
+        pr_title_prompt = build_context_prompt(PR_TITLE_PREFIX, diff_output)
+        pr_body_prompt = build_context_prompt(PR_BODY_PREFIX, diff_output)
 
-    with concurrent.futures.ThreadPoolExecutor() as executor:
-        future_title = executor.submit(
-            settings.mindflow_models.query.model, pr_title_prompt
-        )
-        future_body = executor.submit(
-            settings.mindflow_models.query.model, pr_body_prompt
-        )
+        with concurrent.futures.ThreadPoolExecutor() as executor:
+            future_title = executor.submit(
+                settings.mindflow_models.query.model, pr_title_prompt
+            )
+            future_body = executor.submit(
+                settings.mindflow_models.query.model, pr_body_prompt
+            )
 
-    pr_title = future_title.result()
-    pr_body = future_body.result()
+        title = future_title.result()
+        body = future_body.result()
+    else:
+        if title is None:
+            pr_title_prompt = build_context_prompt(PR_TITLE_PREFIX, diff_output)
+            title = settings.mindflow_models.query.model(pr_title_prompt)
+        if body is None:
+            pr_body_prompt = build_context_prompt(PR_BODY_PREFIX, diff_output)
+            body = settings.mindflow_models.query.model(pr_body_prompt)
 
-    create_pull_request(pr_title, pr_body)
+    return title, body
 
 
 def needs_push() -> bool:
@@ -69,22 +92,22 @@ def needs_push() -> bool:
     return "Your branch is ahead of" in git_status
 
 
-def has_remote_branch(current_branch: str) -> bool:
+def has_remote_branch(head_branch: str) -> bool:
     """
     Returns True if there is a remote branch for the current branch, False otherwise.
     """
     # Check if there is a remote branch for the current branch
     try:
         subprocess.check_output(
-            ["git", "ls-remote", "--exit-code", "--heads", "origin", current_branch]
+            ["git", "ls-remote", "--exit-code", "--heads", "origin", head_branch]
         )
         return True
     except subprocess.CalledProcessError:
         return False
 
 
-def create_pull_request(title, body):
-    command: List[str] = ["gh", "pr", "create", "--title", title, "--body", body]  # type: ignore
+def create_pull_request(args: Tuple[str], title: str, body: str):
+    command: List[str] = ["gh", "pr", "create"] + + list(args) + ["--title", title, "--body", body] # type: ignore
     pr_result = subprocess.check_output(command).decode("utf-8")
     if "https://" in pr_result:
         print("Pull request created successfully")

--- a/mindflow/core/git/pr.py
+++ b/mindflow/core/git/pr.py
@@ -109,7 +109,7 @@ def has_remote_branch(head_branch: str) -> bool:
 
 
 def create_pull_request(args: Tuple[str], title: str, body: str):
-    command: List[str] = ["gh", "pr", "create"] + + list(args) + ["--title", title, "--body", body] # type: ignore
+    command: List[str] = ["gh", "pr", "create"] + list(args) + ["--title", title, "--body", body] # type: ignore
     pr_result = subprocess.check_output(command).decode("utf-8")
     if "https://" in pr_result:
         print("Pull request created successfully")

--- a/mindflow/core/git/pr.py
+++ b/mindflow/core/git/pr.py
@@ -21,7 +21,7 @@ def run_pr(args: Tuple[str], title: Optional[str] = None, body: Optional[str] = 
 
     create_pull_request(args, title, body)
 
-def is_valid_pr(head_branch: Optional[str], base_branch: Optional[str]):
+def is_valid_pr(head_branch: Optional[str], base_branch: Optional[str]) -> bool:
     if head_branch is None:
         # Get the name of the current branch
         head_branch = (
@@ -41,15 +41,17 @@ def is_valid_pr(head_branch: Optional[str], base_branch: Optional[str]):
 
     if head_branch == base_branch:
         print("Cannot create pull request from default branch")
-        return
+        return False
 
     if not has_remote_branch(head_branch):
         print("No remote branch for current branch")
-        return
+        return False
 
     if needs_push():
         print("Current branch needs to be pushed to remote repository")
-        return
+        return False
+
+    return True
 
 def create_title_and_body(base_branch, title: Optional[str], body: Optional[str]) -> Tuple[str, str]:
     settings = Settings()

--- a/mindflow/utils/command_parse.py
+++ b/mindflow/utils/command_parse.py
@@ -1,0 +1,19 @@
+from typing import List, Tuple, Optional
+
+def get_flag_value(args: Tuple[str], flag: List[str]) -> Optional[str]:
+    """
+    Gets the value of a flag in a list of arguments.
+    """
+    for i, arg in enumerate(args):
+        if arg in flag:
+            try:
+                return args[i + 1]
+            except IndexError:
+                return None
+    return None
+
+def get_flag_bool(args: Tuple[str], flag: str) -> bool:
+     try:
+        return args.index(flag) >= 0
+     except:
+        return False

--- a/mindflow/utils/diff_parser.py
+++ b/mindflow/utils/diff_parser.py
@@ -1,7 +1,32 @@
 import os
 
 # NOTE: make sure to have a the "." in the file extension (if applicable)
-IGNORE_FILE_EXTENSIONS = [".pyc", ".ipynb", ".ipynb_checkpoints"]
+# NOTE: these are things that WON'T already be git ignored.
+IGNORE_FILE_EXTENSIONS = [
+    ".pyc",
+    ".ipynb",
+    ".ipynb_checkpoints",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".svg",
+    ".gif",
+    ".mp4",
+    ".mp3",
+    ".mov",
+    ".wav",
+    ".avi",
+    ".zip",
+    ".tar",
+    ".gzip",
+    ".pth",
+    ".pt",
+    ".exe",
+    ".jar",
+    ".csv",  # maybe not?
+    ".bmp",
+    ".emg",
+]
 
 
 def parse_git_diff(diff_str: str):


### PR DESCRIPTION
This pull request includes a number of changes to the Mindflow codebase, including updates to the version number, the addition of new files and functions, and modifications to existing functions. 

Some of the key changes include:

- The `parse_git_diff_file` function has been renamed to `parse_git_diff` and now takes a string as input instead of a file path. It returns a tuple of two values: the diffs dictionary and a list of excluded files.
- A new file, `command_parse.py`, has been added with two functions: `get_flag_value` and `get_flag_bool`.
- A new file, `diff_parser.py`, has been added with a function `parse_git_diff` that takes a string of git diff output and returns a dictionary of file names and their diffs, as well as a list of excluded files.
- The `IGNORE_FILE_EXTENSIONS` list has been added to `diff_parser.py`, which includes file extensions for common image, video, audio, archive, and binary file types.
- The `run_pr` function has been added to `git/__init__.py`, which takes in `args`, `title`, and `body` as arguments.
- The `create_title_and_body` function has been added to `run_pr`, which creates the title and body of the pull request if they are not provided.
- The `create_merge_request` function has been added to `mr.py`, which creates a merge request using `glab pr create` command.
- The `passthrough_command` function has been added to `util.py`, which allows all args to pass through (for wrapper cli commands).

These changes aim to improve the functionality and usability of Mindflow, making it easier for users to create and manage pull requests.