### PR TITLE
Update return type and method names in various files.

### DIFF
--- a/mindflow/cli/new_click_cli/commands/index.py
+++ b/mindflow/cli/new_click_cli/commands/index.py
@@ -12,7 +12,6 @@ from mindflow.core.index import run_index
     help="Index path(s). You can pass as many folders/files/paths as you'd like. Pass `.` to reference all "
 )
 @click.argument("document_paths", type=str, nargs=-1, required=True)
-@click.option("--force", is_flag=True, default=False)
 @click.option("--refresh", is_flag=True, default=False)
-def index(document_paths: List[str], refresh: bool, force: bool) -> None:
-    run_index(document_paths, refresh, force)
+def index(document_paths: List[str], refresh: bool) -> None:
+    run_index(document_paths, refresh)

--- a/mindflow/core/delete.py
+++ b/mindflow/core/delete.py
@@ -12,11 +12,11 @@ def run_delete(document_paths: List[str]):
     """
     This function is used to delete your MindFlow index.
     """
-    documents_references = [
-        document_reference.path for document_reference in resolve_all(document_paths)
+    resolved_paths = [
+        resolved_path["path"] for resolved_path in resolve_all(document_paths)
     ]
     documents_to_delete = [
-        document.path for document in Document.load_bulk(documents_references)
+        document.path for document in Document.load_bulk(resolved_paths)
     ]
 
     if len(documents_to_delete) == 0:

--- a/mindflow/core/inspect.py
+++ b/mindflow/core/inspect.py
@@ -13,10 +13,12 @@ def run_inspect(document_paths: List[str]) -> str:
     """
     This function is used to inspect your MindFlow index.
     """
-    document_paths = [document.path for document in resolve_all(document_paths)]
+    resolved_paths = [
+        resolved_path["path"] for resolved_path in resolve_all(document_paths)
+    ]
     inspect_output = json.dumps(
         DATABASE_CONTROLLER.databases.json.load_bulk(
-            Collection.DOCUMENT.value, document_paths
+            Collection.DOCUMENT.value, resolved_paths
         ),
         indent=4,
     )

--- a/mindflow/db/objects/document.py
+++ b/mindflow/db/objects/document.py
@@ -70,8 +70,8 @@ class DocumentReference(BaseObject):
 
     @classmethod
     def from_resolved(
-        cls, resolved: Dict, model: ConfiguredModel
-    ) -> "DocumentReference":
+        cls, resolved: List[Dict], model: ConfiguredModel
+    ) -> List["DocumentReference"]:
         """
         Create document reference from resolved
         """

--- a/mindflow/db/objects/document.py
+++ b/mindflow/db/objects/document.py
@@ -1,9 +1,11 @@
 import hashlib
-from typing import Optional
+from typing import Dict, List, Optional
 
 from mindflow.db.db.database import Collection
 from mindflow.db.objects.base import BaseObject
+from mindflow.db.objects.model import ConfiguredModel
 from mindflow.db.objects.static_definition.document import DocumentType
+from mindflow.utils.token import get_token_count
 
 
 class Document(BaseObject):
@@ -26,19 +28,12 @@ class Document(BaseObject):
         """
         Create document reference
         """
-        document_text: Optional[str] = read_document(self.id, self.document_type)
-        if not document_text:
-            raise Exception("Document text not found")
-
-        document_text_bytes = document_text.encode("utf-8")
         return DocumentReference(
             {
                 "id": self.id,
                 "path": self.path,
                 "document_type": self.document_type,
-                "size": len(document_text_bytes),
-                "hash": hashlib.sha256(document_text_bytes).hexdigest(),
-                "old_hash": self.hash,
+                "hash": self.hash,
             }
         )
 
@@ -51,9 +46,11 @@ class DocumentReference(BaseObject):
     id: str
     path: str
     document_type: str
+
     size: int
-    hash: str
-    old_hash: Optional[str]
+    hash: Optional[str]
+    new_hash: str
+    tokens: int
 
     def to_document(
         self,
@@ -67,32 +64,50 @@ class DocumentReference(BaseObject):
                 "path": self.path,
                 "document_type": self.document_type,
                 "size": self.size,
-                "hash": self.hash,
+                "hash": self.new_hash,
             }
         )
 
     @classmethod
-    def from_path(
-        cls,
-        document_path: str,
-        document_type: DocumentType,
-    ) -> Optional["DocumentReference"]:
+    def from_resolved(
+        cls, resolved: Dict, model: ConfiguredModel
+    ) -> "DocumentReference":
         """
-        Create document reference from path
+        Create document reference from resolved
         """
-        document_text: Optional[str] = read_document(document_path, document_type.value)
-        if not document_text:
-            return None
-        document_text_bytes = document_text.encode()
-        return cls(
-            {
-                "id": document_path,
-                "path": document_path,
-                "document_type": document_type.value,
-                "size": len(document_text_bytes),
-                "hash": hashlib.sha256(document_text_bytes).hexdigest(),
-            }
-        )
+        document_references: List[DocumentReference] = []
+        for resolved_ref in resolved:
+            document_reference = cls(resolved_ref)
+            document = Document.load(resolved_ref["path"])
+            if document:
+                document_reference.hash = document.hash
+
+            document_text: Optional[str] = read_document(
+                document_reference.id, document_reference.document_type
+            )
+            if not document_text:
+                print(f"Unable to read document text: {document_reference.id}")
+                continue
+
+            document_text_bytes = document_text.encode("utf-8")
+
+            document_reference.new_hash = hashlib.sha256(
+                document_text_bytes
+            ).hexdigest()
+            document_reference.size = len(document_text_bytes)
+            document_reference.tokens = get_token_count(model, document_text)
+
+            document_references.append(document_reference)
+
+        return document_references
+
+    def is_new(self) -> bool:
+        """
+        Check if document is new
+        """
+        if not hasattr(self, "hash") or not self.hash:
+            return True
+        return self.hash != self.new_hash
 
 
 def read_document(document_path: str, document_type: str) -> Optional[str]:

--- a/mindflow/resolving/resolve.py
+++ b/mindflow/resolving/resolve.py
@@ -3,13 +3,15 @@ Module for resolving documents to text.
 """
 import sys
 from typing import List
-from typing import Optional
+from typing import Optional, Dict
 
 from mindflow.db.objects.document import DocumentReference
 from mindflow.resolving.resolvers.file_resolver import FileResolver
 
 
-def resolve(document_path: str) -> List[DocumentReference]:
+def resolve(
+    document_path: str,
+) -> List[Dict]:
     """
     Resolves a document to text.
     """
@@ -23,33 +25,8 @@ def resolve(document_path: str) -> List[DocumentReference]:
     sys.exit(1)
 
 
-def resolve_all(document_paths: List[str]) -> List[DocumentReference]:
-    document_references: List[DocumentReference] = []
+def resolve_all(document_paths: List[str]) -> List[Dict]:
+    document_references: List[Dict] = []
     for document_path in document_paths:
         document_references.extend(resolve(document_path))
     return document_references
-
-
-def return_if_indexable(
-    document_references: List[DocumentReference], refresh: bool, force: bool
-) -> List[DocumentReference]:
-    return [
-        document_reference
-        for document_reference in document_references
-        if index_document(document_reference, refresh, force)
-    ]
-
-
-def index_document(
-    document_reference: DocumentReference, refresh: bool, force: Optional[bool]
-) -> bool:
-    if refresh:
-        if not document_reference.old_hash:
-            return False
-        if document_reference.old_hash == document_reference.hash and not force:
-            return False
-        return True
-
-    if not hasattr(document_reference, "old_hash") or force:
-        return True
-    return False

--- a/mindflow/resolving/resolvers/base_resolver.py
+++ b/mindflow/resolving/resolvers/base_resolver.py
@@ -1,7 +1,7 @@
 """
 Base Resolver Class
 """
-from typing import List
+from typing import List, Dict
 
 from mindflow.db.objects.document import DocumentReference
 
@@ -18,7 +18,7 @@ class BaseResolver:
         """
         return False
 
-    def resolve(self, document_path: str) -> List[DocumentReference]:
+    def resolve(self, document_path: str) -> List[Dict]:
         """
         Resolve a document path to text.
         """

--- a/mindflow/resolving/resolvers/file_resolver.py
+++ b/mindflow/resolving/resolvers/file_resolver.py
@@ -2,12 +2,8 @@
 File/Directory Resolver
 """
 import os
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Dict, List, Union
 
-from mindflow.db.objects.document import Document
-from mindflow.db.objects.document import DocumentReference
 from mindflow.db.objects.static_definition.document import DocumentType
 from mindflow.resolving.resolvers.base_resolver import BaseResolver
 from mindflow.utils.files.extract import extract_files
@@ -25,23 +21,11 @@ class FileResolver(BaseResolver):
         """
         return os.path.isfile(document_path) or os.path.isdir(document_path)
 
-    def resolve(self, document_path: str) -> List[DocumentReference]:
+    def resolve(self, document_path: str) -> List[Dict]:
         """
         Extract text from files.
         """
-        document_references: List[DocumentReference] = []
-        for path in extract_files(document_path):
-            document_reference: Optional[DocumentReference] = None
-            document = Document.load(path)
-
-            if document:
-                document_reference = document.to_document_reference()
-            else:
-                document_reference = DocumentReference.from_path(
-                    path, DocumentType.FILE
-                )
-
-            if document_reference:
-                document_references.append(document_reference)
-
-        return document_references
+        return [
+            {"id": path, "path": path, "document_type": DocumentType.FILE.value}
+            for path in extract_files(document_path)
+        ]

--- a/mindflow/utils/helpers.py
+++ b/mindflow/utils/helpers.py
@@ -1,0 +1,38 @@
+import sys
+from typing import List
+
+from mindflow.db.objects.document import DocumentReference
+from mindflow.db.objects.model import ConfiguredModel
+
+
+def print_total_size(document_references: List[DocumentReference]):
+    """
+    Print total size of documents
+    """
+    total_size = sum(
+        [document_reference.size for document_reference in document_references]
+    )
+    print(f"Total content size: MB {total_size / 1024 / 1024:.2f}")
+
+
+def print_total_tokens_and_ask_to_continue(
+    document_references: List[DocumentReference], completion_model: ConfiguredModel
+):
+    """
+    Print total tokens of documents
+    """
+    total_tokens = sum(
+        [document_reference.tokens for document_reference in document_references]
+    )
+    print(f"Total tokens: {total_tokens}")
+    total_cost_usd: float = (
+        total_tokens / completion_model.token_cost_unit
+    ) * completion_model.token_cost
+    if total_cost_usd > 0.50:
+        print(f"Total cost: ${total_cost_usd:.2f}")
+        while True:
+            user_input = input("Would you like to continue? (yes/no): ")
+            if user_input.lower() in ["no", "n"]:
+                sys.exit(0)
+            elif user_input.lower() in ["yes", "y"]:
+                break

--- a/mindflow/utils/helpers.py
+++ b/mindflow/utils/helpers.py
@@ -26,7 +26,7 @@ def print_total_tokens_and_ask_to_continue(
     )
     print(f"Total tokens: {total_tokens}")
     total_cost_usd: float = (
-        total_tokens / completion_model.token_cost_unit
+        total_tokens / float(completion_model.token_cost_unit)
     ) * completion_model.token_cost
     if total_cost_usd > 0.50:
         print(f"Total cost: ${total_cost_usd:.2f}")


### PR DESCRIPTION
This pull request includes changes to various files in the project. Here are the core themes and reasons for the changes:

- `base_resolver.py` and `file_resolver.py`: The return type of the `resolve` method has been changed from `List[DocumentReference]` to `List[Dict]`. This change was made to simplify the code and make it more readable.

- `helpers.py`: A new file has been added, and two new methods have been added to it: `print_total_size` and `print_total_tokens_and_ask_to_continue`. These methods are used to print the total size and tokens of the indexed documents.

- `b/mindflow/cli/new_click_cli/commands/index.py`: The `force` option has been removed from the `index` function.

- `b/mindflow/core/delete.py`: The names of some variables and methods have been changed to make the code more readable.

- `b/mindflow/core/index.py`: The `force` parameter has been removed from the `run_index` function. Some variable and method names have been changed to make the code more readable. The `total_size` variable has been replaced with `print_total_size`. The `print(f"Total content size: MB {total_size / 1024 / 1024:.2f}")` line has been replaced with `print_total_tokens_and_ask_to_continue`.

- `b/mindflow/core/inspect.py` and `b/mindflow/core/query.py`: Some variable and method names have been changed to make the code more readable.

- `b/mindflow/db/objects/document.py`: The `DocumentReference` class has been updated with new attributes and methods to make the code more readable.

- `b/mindflow/resolving/resolve.py`: Some variable and method names have been changed to make the code more readable. The return type of the `resolve` and `resolve_all` methods has been changed to `List[Dict]`.